### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,5 +41,5 @@ inputs:
     default: ''
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'src/run-on-arch.js'


### PR DESCRIPTION
For now is only warning, but it will be error ...

build-vcpkg-deps-linux:
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: Kingtous/run-on-arch-action@amd64-support.

For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.